### PR TITLE
feat(client): support websocket protocols param

### DIFF
--- a/dxlink-javascript/dxlink-websocket-client/src/client.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/client.ts
@@ -105,7 +105,12 @@ export class DXLinkWebSocketClient implements DXLinkClient {
     this.logger = new Logger(this.constructor.name, this.config.logLevel)
   }
 
-  connect = (url: string) => {
+  /**
+   * Connect to the remote dxLink WebSocket endpoint.
+   * @param url URL to connect to.
+   * @param protocols WebSocket constructor `protocols` param.
+   */
+  connect = (url: string, protocols?: string | string[]) => {
     // Do nothing if already connected to the same url
     if (this.connector?.getUrl() === url) return
 
@@ -117,7 +122,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
     // Immediately set connection state to CONNECTING
     this.setConnectionState(DXLinkConnectionState.CONNECTING)
 
-    this.connector = new WebSocketConnector(url)
+    this.connector = new WebSocketConnector(url, protocols)
     this.connector.setOpenListener(this.processTransportOpen)
     this.connector.setMessageListener(this.processMessage)
     this.connector.setCloseListener(this.processTransportClose)
@@ -128,7 +133,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
   reconnect = () => {
     if (
-      this.config.maxReconnectAttempts > 0 &&
+      this.config.maxReconnectAttempts >= 0 &&
       this.reconnectAttempts >= this.config.maxReconnectAttempts
     ) {
       this.logger.warn('Max reconnect attempts reached')

--- a/dxlink-javascript/dxlink-websocket-client/src/client.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/client.ts
@@ -133,7 +133,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
   reconnect = () => {
     if (
-      this.config.maxReconnectAttempts >= 0 &&
+      this.config.maxReconnectAttempts > 0 &&
       this.reconnectAttempts >= this.config.maxReconnectAttempts
     ) {
       this.logger.warn('Max reconnect attempts reached')

--- a/dxlink-javascript/dxlink-websocket-client/src/connector.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/connector.ts
@@ -15,12 +15,12 @@ export class WebSocketConnector {
   private closeListener: CloseListener | undefined = undefined
   private messageListener: ((message: Message) => void) | undefined = undefined
 
-  constructor(private readonly url: string) {}
+  constructor(private readonly url: string, private readonly protocols?: string | string[]) {}
 
   start() {
     if (this.socket !== undefined) return
 
-    this.socket = new WebSocket(this.url)
+    this.socket = new WebSocket(this.url, this.protocols)
 
     this.socket.addEventListener('open', this.handleOpen)
     this.socket.addEventListener('error', this.handleError)


### PR DESCRIPTION
This PR:
- Adds an optional `protocols` param to the client.connect method to support the WebSocket constructor's [`protocols` param](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#protocols).

Note: we have `pnpm` patched this change internally and have been using it in production.