### PR TITLE
fix(client): fix maxReconnectAttempts reconnect logic

### DIFF
--- a/dxlink-javascript/dxlink-websocket-client/src/client.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/client.ts
@@ -128,7 +128,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
   reconnect = () => {
     if (
-      this.config.maxReconnectAttempts > 0 &&
+      this.config.maxReconnectAttempts >= 0 &&
       this.reconnectAttempts >= this.config.maxReconnectAttempts
     ) {
       this.logger.warn('Max reconnect attempts reached')


### PR DESCRIPTION
This PR:
- fixes a check in the WebSocketConnector reconnection logic. For clients that set `this.config.maxReconnectAttempts` to 0, the current `this.config.maxReconnectAttempts > 0` will never hit.
- 
Note: we have pnpm patched this change internally and have been using it in production.