### PR TITLE
feat(websocket): allows custom WebSocket connector

### DIFF
--- a/dxlink-javascript/dxlink-websocket-client/src/channel.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/channel.ts
@@ -11,7 +11,7 @@ import {
 } from '@dxfeed/dxlink-core'
 
 import { type DXLinkWebSocketClientConfig } from './config'
-import { type ChannelPayloadMessage, type Message } from './messages'
+import { type ChannelPayloadMessage, type DXLinkWebSocketMessage } from './messages'
 
 /**
  * A DXLink channel implementation.
@@ -31,7 +31,7 @@ export class DXLinkWebSocketChannel implements DXLinkChannel {
     public readonly id: number,
     public readonly service: string,
     public readonly parameters: Record<string, unknown>,
-    private readonly sendMessage: (message: Message) => void,
+    private readonly sendMessage: (message: DXLinkWebSocketMessage) => void,
     config: DXLinkWebSocketClientConfig
   ) {
     this.logger = new Logger(`${DXLinkWebSocketChannel.name}#${id} ${service}`, config.logLevel)

--- a/dxlink-javascript/dxlink-websocket-client/src/config.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/config.ts
@@ -1,5 +1,7 @@
 import type { DXLinkLogLevel } from '@dxfeed/dxlink-core'
 
+import type { DXLinkWebSocketConnector } from './connector'
+
 /**
  * Options for {@link DXLinkWebSocketClient}.
  */
@@ -32,4 +34,12 @@ export interface DXLinkWebSocketClientConfig {
    * If 0, then reconnect attempts are not limited.
    */
   readonly maxReconnectAttempts: number
+  /**
+   * Factory function to create a WebSocket connector.
+   * This function should return an instance of {@link DXLinkWebSocketConnector} for the given URL.
+   * This allows for custom WebSocket implementations or configurations.
+   * @param url The URL to connect to.
+   * @returns {@link DXLinkWebSocketConnector} instance
+   */
+  readonly connectorFactory: (url: string) => DXLinkWebSocketConnector
 }

--- a/dxlink-javascript/dxlink-websocket-client/src/index.test.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/index.test.ts
@@ -2,11 +2,11 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 
 import { DXLinkWebSocketChannel } from './channel'
-import type { Message } from './messages'
+import type { DXLinkWebSocketMessage } from './messages'
 
 test(`Channel`, () => {
   let requestCalled = false
-  const sendMessage = (message: Message) => {
+  const sendMessage = (message: DXLinkWebSocketMessage) => {
     if (message.type === 'CHANNEL_REQUEST') {
       requestCalled = true
     }

--- a/dxlink-javascript/dxlink-websocket-client/src/index.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/index.ts
@@ -1,2 +1,9 @@
 export { DXLinkWebSocketClient, DXLINK_WS_PROTOCOL_VERSION } from './client'
 export { type DXLinkWebSocketClientConfig } from './config'
+
+export {
+  type DXLinkWebSocketConnector,
+  type DXLinkWebSocketCloseListener,
+  DefaultDXLinkWebSocketConnector,
+} from './connector'
+export { type DXLinkWebSocketMessage } from './messages'

--- a/dxlink-javascript/dxlink-websocket-client/src/messages.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/messages.ts
@@ -84,7 +84,7 @@ export type ConnectionMessage =
   | AuthStateMessage
   | ErrorMessage
 
-export type Message =
+export type DXLinkWebSocketMessage =
   | SetupMessage
   | KeepaliveMessage
   | AuthMessage
@@ -97,7 +97,9 @@ export type Message =
   | ChannelPayloadMessage
   | ChannelErrorMessage
 
-export const isConnectionMessage = (message: Message): message is ConnectionMessage =>
+export const isConnectionMessage = (
+  message: DXLinkWebSocketMessage
+): message is ConnectionMessage =>
   message.channel === 0 &&
   (message.type === 'SETUP' ||
     message.type === 'KEEPALIVE' ||
@@ -114,7 +116,7 @@ export type ChannelLifecycleMessage =
 
 export type ChannelMessage = ChannelLifecycleMessage | ChannelPayloadMessage
 
-export const isChannelMessage = (message: Message): message is ChannelMessage =>
+export const isChannelMessage = (message: DXLinkWebSocketMessage): message is ChannelMessage =>
   message.channel !== 0
 
 export const isChannelLifecycleMessage = (


### PR DESCRIPTION
Adds the ability to provide a custom WebSocket connector implementation via a `connectorFactory` in the client configuration.

This allows users to integrate custom WebSocket libraries or configurations for specific environments or requirements, promoting flexibility and control over the underlying transport.