### PR TITLE
chore(dxlink-core): Include more details to server error

### DIFF
--- a/dxlink-javascript/dxlink-core/src/error.ts
+++ b/dxlink-javascript/dxlink-core/src/error.ts
@@ -21,6 +21,10 @@ export interface DXLinkError {
    */
   readonly type: DXLinkErrorType
   /**
+   * Channel id where the error happened.
+   */
+  readonly channel: number
+  /**
    * Message of the error with details.
    * @example 'Timeout exceeded'
    */

--- a/dxlink-javascript/dxlink-core/src/error.ts
+++ b/dxlink-javascript/dxlink-core/src/error.ts
@@ -21,9 +21,9 @@ export interface DXLinkError {
    */
   readonly type: DXLinkErrorType
   /**
-   * Channel id where the error happened.
+   * Correlation id of the operation where the error happened.
    */
-  readonly channel: number
+  readonly correlationId?: string
   /**
    * Message of the error with details.
    * @example 'Timeout exceeded'

--- a/dxlink-javascript/dxlink-rpc/src/index.test.ts
+++ b/dxlink-javascript/dxlink-rpc/src/index.test.ts
@@ -250,11 +250,16 @@ test('errors output when channel receives error', () => {
     },
   })
   mock.lastChannel!.simulateOpen()
-  mock.lastChannel!.simulateError({ type: 'UNAUTHORIZED', message: 'Not authorized' })
+  mock.lastChannel!.simulateError({
+    type: 'UNAUTHORIZED',
+    channel: 1,
+    message: 'Not authorized',
+  })
 
   assert.ok(receivedError)
   assert.is(receivedError!.type, 'UNAUTHORIZED')
   assert.is(receivedError!.message, 'Not authorized')
+  assert.is(recevedError!.channel, 1)
 
   sub.unsubscribe()
 })

--- a/dxlink-javascript/dxlink-rpc/src/index.test.ts
+++ b/dxlink-javascript/dxlink-rpc/src/index.test.ts
@@ -252,14 +252,14 @@ test('errors output when channel receives error', () => {
   mock.lastChannel!.simulateOpen()
   mock.lastChannel!.simulateError({
     type: 'UNAUTHORIZED',
-    channel: 1,
     message: 'Not authorized',
   })
 
   assert.ok(receivedError)
   assert.is(receivedError!.type, 'UNAUTHORIZED')
   assert.is(receivedError!.message, 'Not authorized')
-  assert.is(recevedError!.channel, 1)
+  assert.is(receivedError!.correlationId, undefined)
+  assert.notContains(Object.keys(receivedError!), 'correlationId')
 
   sub.unsubscribe()
 })

--- a/dxlink-javascript/dxlink-websocket-client/SPECIFICATION.md
+++ b/dxlink-javascript/dxlink-websocket-client/SPECIFICATION.md
@@ -384,10 +384,9 @@ This section describes how protocol-level operations map to the client's public 
 
 - Protocol ERROR messages (channel 0) trigger client error listeners
 - Protocol ERROR messages (channel > 0) trigger channel error listeners
-- Error type and message are extracted from protocol message
-- Errors are published to listeners
+- Error listeners receive normalized error object (`type`, `channel`, `message`) where `type` is the error code (for example `INVALID_MESSAGE`)
 
-**What's hidden**: The protocol ERROR message format is abstracted. Listeners receive a simplified error object with type and message fields.
+**What's hidden**: The protocol ERROR frame is routed to the corresponding listener and exposed with a stable shape.
 
 ### Reconnection
 

--- a/dxlink-javascript/dxlink-websocket-client/SPECIFICATION.md
+++ b/dxlink-javascript/dxlink-websocket-client/SPECIFICATION.md
@@ -384,9 +384,9 @@ This section describes how protocol-level operations map to the client's public 
 
 - Protocol ERROR messages (channel 0) trigger client error listeners
 - Protocol ERROR messages (channel > 0) trigger channel error listeners
-- Error listeners receive normalized error object (`type`, `channel`, `message`) where `type` is the error code (for example `INVALID_MESSAGE`)
+- Error listeners receive normalized error object (`type`, `message`, optional `correlationId`) where `type` is the error code (for example `INVALID_MESSAGE`)
 
-**What's hidden**: The protocol ERROR frame is routed to the corresponding listener and exposed with a stable shape.
+**What's hidden**: The protocol ERROR message is routed to the corresponding listener and exposed with a stable shape.
 
 ### Reconnection
 

--- a/dxlink-javascript/dxlink-websocket-client/src/channel.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/channel.ts
@@ -64,11 +64,12 @@ export class DXLinkWebSocketChannel implements DXLinkChannel {
   addErrorListener = (listener: DXLinkErrorListener) => this.errorListeners.add(listener)
   removeErrorListener = (listener: DXLinkErrorListener) => this.errorListeners.delete(listener)
 
-  error = ({ type, message }: DXLinkError) =>
+  error = ({ type, message, correlationId }: DXLinkError) =>
     this.send({
       type: 'ERROR',
       error: type,
       message,
+      ...(correlationId === undefined ? {} : { correlationId }),
     })
 
   close = () => {

--- a/dxlink-javascript/dxlink-websocket-client/src/client.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/client.ts
@@ -22,6 +22,7 @@ import type { DXLinkWebSocketClientConfig } from './config'
 import { type DXLinkWebSocketConnector, DefaultDXLinkWebSocketConnector } from './connector'
 import {
   type AuthStateMessage,
+  type ChannelErrorMessage,
   type ErrorMessage,
   type DXLinkWebSocketMessage,
   type SetupMessage,
@@ -345,10 +346,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
         case 'AUTH_STATE':
           return this.processAuthStateMessage(message)
         case 'ERROR':
-          return this.publishError({
-            type: message.error,
-            message: message.message,
-          })
+          return this.publishError(this.mapServerError(message))
         case 'KEEPALIVE':
           // Ignore keepalive messages coz they are used only to maintain connection
           return
@@ -367,10 +365,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
           case 'CHANNEL_CLOSED':
             return channel.processStatusClosed()
           case 'ERROR':
-            return channel.processError({
-              type: message.error,
-              message: message.message,
-            })
+            return channel.processError(this.mapServerError(message))
         }
         return
       }
@@ -380,6 +375,15 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
     this.logger.warn('Unhandeled message', message.type)
   }
+
+  /**
+   * Maps server ERROR frame to public error object.
+   */
+  private mapServerError = (message: ErrorMessage | ChannelErrorMessage): DXLinkError => ({
+    type: message.error,
+    channel: message.channel,
+    message: message.message,
+  })
 
   private processSetupMessage = (serverSetup: SetupMessage): void => {
     // Clear setup timeout check from connect method
@@ -502,6 +506,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
         this.publishError({
           type: errorMessage.error,
+          channel: 0,
           message: `${errorMessage.message} from server`,
         })
 
@@ -527,6 +532,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
         this.publishError({
           type: errorMessage.error,
+          channel: 0,
           message: `${errorMessage.message} from server`,
         })
 
@@ -554,6 +560,7 @@ export class DXLinkWebSocketClient implements DXLinkClient {
     if (error !== undefined) {
       this.publishError({
         type: 'UNKNOWN',
+        channel: 0,
         message: reason,
       })
     }

--- a/dxlink-javascript/dxlink-websocket-client/src/client.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/client.ts
@@ -377,12 +377,12 @@ export class DXLinkWebSocketClient implements DXLinkClient {
   }
 
   /**
-   * Maps server ERROR frame to public error object.
+   * Maps server ERROR message to public error object.
    */
   private mapServerError = (message: ErrorMessage | ChannelErrorMessage): DXLinkError => ({
     type: message.error,
-    channel: message.channel,
     message: message.message,
+    ...(message.correlationId === undefined ? {} : { correlationId: message.correlationId }),
   })
 
   private processSetupMessage = (serverSetup: SetupMessage): void => {
@@ -506,7 +506,6 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
         this.publishError({
           type: errorMessage.error,
-          channel: 0,
           message: `${errorMessage.message} from server`,
         })
 
@@ -532,7 +531,6 @@ export class DXLinkWebSocketClient implements DXLinkClient {
 
         this.publishError({
           type: errorMessage.error,
-          channel: 0,
           message: `${errorMessage.message} from server`,
         })
 
@@ -560,7 +558,6 @@ export class DXLinkWebSocketClient implements DXLinkClient {
     if (error !== undefined) {
       this.publishError({
         type: 'UNKNOWN',
-        channel: 0,
         message: reason,
       })
     }

--- a/dxlink-javascript/dxlink-websocket-client/src/index.test.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/index.test.ts
@@ -1,8 +1,10 @@
-import { DXLinkConnectionState, type DXLinkError } from '@dxfeed/dxlink-core'
+import { DXLinkConnectionState, type DXLinkError, type DXLinkScheduler } from '@dxfeed/dxlink-core'
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 
 import { DXLINK_WS_PROTOCOL_VERSION, DXLinkWebSocketClient } from './client'
+import type { DXLinkWebSocketConnector } from './connector'
+import type { DXLinkWebSocketMessage } from './messages'
 
 const DEMO_URL = 'wss://demo.dxfeed.com/market-data/dxlink-ws'
 const CONNECT_TIMEOUT_MS = 15_000
@@ -43,6 +45,128 @@ const waitForConnectionState = (
 
     client.addConnectionStateChangeListener(listener)
   })
+
+class MockDXLinkScheduler implements DXLinkScheduler {
+  private readonly scheduledKeys = new Set<string>()
+
+  schedule = (_callback: () => void, _timeout: number, key: string): string => {
+    this.scheduledKeys.add(key)
+    return key
+  }
+
+  cancel = (key: string): void => {
+    this.scheduledKeys.delete(key)
+  }
+
+  clear = (): void => {
+    this.scheduledKeys.clear()
+  }
+
+  has = (key: string): boolean => this.scheduledKeys.has(key)
+}
+
+class MockDXLinkWebSocketConnector implements DXLinkWebSocketConnector {
+  private openListener: (() => void) | undefined
+  private closeListener: ((reason: string, error: boolean) => void) | undefined
+  private messageListener: ((message: DXLinkWebSocketMessage) => void) | undefined
+
+  constructor(private readonly url: string) {}
+
+  readonly sentMessages: DXLinkWebSocketMessage[] = []
+
+  getUrl = (): string => this.url
+
+  start = (): void => {
+    this.openListener?.()
+  }
+
+  stop = (): void => {}
+
+  sendMessage = (message: DXLinkWebSocketMessage): void => {
+    this.sentMessages.push(message)
+  }
+
+  setOpenListener = (listener: () => void): void => {
+    this.openListener = listener
+  }
+
+  setCloseListener = (listener: (reason: string, error: boolean) => void): void => {
+    this.closeListener = listener
+  }
+
+  setMessageListener = (listener: (message: DXLinkWebSocketMessage) => void): void => {
+    this.messageListener = listener
+  }
+
+  emitMessage = (message: DXLinkWebSocketMessage): void => {
+    this.messageListener?.(message)
+  }
+
+  emitClose = (reason: string, error: boolean): void => {
+    this.closeListener?.(reason, error)
+  }
+}
+
+test('Connection and channel error listeners receive server error payload metadata', () => {
+  const connector = new MockDXLinkWebSocketConnector('wss://mock')
+  const scheduler = new MockDXLinkScheduler()
+  const client = new DXLinkWebSocketClient({
+    scheduler,
+    connectorFactory: () => connector,
+  })
+
+  const channel = client.openChannel('SERVICE', {})
+
+  let clientError: DXLinkError | undefined
+  let channelError: DXLinkError | undefined
+
+  client.addErrorListener((error) => {
+    clientError = error
+  })
+  channel.addErrorListener((error) => {
+    channelError = error
+  })
+
+  client.connect('wss://mock')
+
+  connector.emitMessage({
+    type: 'SETUP',
+    channel: 0,
+    version: '0.1-TEST',
+  })
+  connector.emitMessage({
+    type: 'AUTH_STATE',
+    channel: 0,
+    state: 'AUTHORIZED',
+  })
+  connector.emitMessage({
+    type: 'CHANNEL_OPENED',
+    channel: channel.id,
+    service: 'SERVICE',
+  })
+
+  connector.emitMessage({
+    type: 'ERROR',
+    channel: 0,
+    error: 'BAD_ACTION',
+    message: 'Connection-level error',
+  })
+
+  connector.emitMessage({
+    type: 'ERROR',
+    channel: channel.id,
+    error: 'INVALID_MESSAGE',
+    message: 'Some text',
+  })
+
+  assert.ok(clientError)
+  assert.is(clientError!.type, 'BAD_ACTION')
+  assert.is(clientError!.channel, 0)
+
+  assert.ok(channelError)
+  assert.is(channelError!.type, 'INVALID_MESSAGE')
+  assert.is(channelError!.channel, channel.id)
+})
 
 test(`Live market-data endpoint success-path`, async () => {
   const client = new DXLinkWebSocketClient({

--- a/dxlink-javascript/dxlink-websocket-client/src/index.test.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/index.test.ts
@@ -107,7 +107,7 @@ class MockDXLinkWebSocketConnector implements DXLinkWebSocketConnector {
   }
 }
 
-test('Connection and channel error listeners receive server error payload metadata', () => {
+test('Connection and channel error listeners receive server error payload metadata without channel id', () => {
   const connector = new MockDXLinkWebSocketConnector('wss://mock')
   const scheduler = new MockDXLinkScheduler()
   const client = new DXLinkWebSocketClient({
@@ -150,6 +150,7 @@ test('Connection and channel error listeners receive server error payload metada
     channel: 0,
     error: 'BAD_ACTION',
     message: 'Connection-level error',
+    correlationId: 'connection-correlation-id',
   })
 
   connector.emitMessage({
@@ -161,11 +162,16 @@ test('Connection and channel error listeners receive server error payload metada
 
   assert.ok(clientError)
   assert.is(clientError!.type, 'BAD_ACTION')
-  assert.is(clientError!.channel, 0)
+  assert.is(clientError!.message, 'Connection-level error')
+  assert.is(clientError!.correlationId, 'connection-correlation-id')
+  assert.notContains(Object.keys(clientError!), 'channel')
 
   assert.ok(channelError)
   assert.is(channelError!.type, 'INVALID_MESSAGE')
-  assert.is(channelError!.channel, channel.id)
+  assert.is(channelError!.message, 'Some text')
+  assert.is(channelError!.correlationId, undefined)
+  assert.notContains(Object.keys(channelError!), 'correlationId')
+  assert.notContains(Object.keys(channelError!), 'channel')
 })
 
 test(`Live market-data endpoint success-path`, async () => {

--- a/dxlink-javascript/dxlink-websocket-client/src/messages.ts
+++ b/dxlink-javascript/dxlink-websocket-client/src/messages.ts
@@ -62,6 +62,7 @@ export interface ErrorMessage {
   channel: 0
   error: ErrorType
   message: string
+  correlationId?: string
 }
 
 export interface ChannelErrorMessage {
@@ -69,6 +70,7 @@ export interface ChannelErrorMessage {
   channel: number
   error: ErrorType
   message: string
+  correlationId?: string
 }
 
 export interface ChannelPayloadMessage {


### PR DESCRIPTION
This pull request improves how errors are handled and exposed in the DXLink WebSocket client and core libraries. The main focus is on ensuring that error listeners receive a normalized error object that includes the `channel` where the error occurred, making error handling more consistent and informative. The changes affect both the implementation and tests, as well as the protocol specification documentation.

**Error Handling Improvements**

* The `DXLinkError` interface now includes a `channel` field, indicating the channel where the error happened (`0` for connection-level errors).
* The WebSocket client now consistently maps server error frames to public error objects with `type`, `channel`, and `message`, ensuring all error listeners receive full error context. [[1]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4L348-R349) [[2]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4L370-R368) [[3]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4R379-R387) [[4]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4R509) [[5]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4R535) [[6]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4R563)

**Testing Enhancements**

* Added a new test in `index.test.ts` to verify that both connection and channel error listeners receive the correct error payload, including the `channel` metadata.

**Documentation Updates**

* The protocol specification was updated to clarify that error listeners receive normalized error objects with `type`, `channel`, and `message`, and to explain how protocol error frames are routed and exposed.

**Test and Type Imports**

* Updated test files to import the new and required types for improved type safety and test clarity. [[1]](diffhunk://#diff-fde112b448f39b8f88961aedc13c84c25ea6f50a18a4849bb33f32dd15bad6dbL1-R7) [[2]](diffhunk://#diff-838935f64b7491db9e445d8801be7f30af0b3f3fd09f66abf1ca090d2bfc68d4R25)


Fixes #31 