### PR TITLE
ci: add npm release pipeline

### DIFF
--- a/.github/scripts/publish-package.sh
+++ b/.github/scripts/publish-package.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Publishes the package in the current directory. Run per package by `pnpm -r exec`.
+#
+# Packing is pnpm's and publishing is npm's, and neither can do the other's: `pnpm pack` rewrites
+# `workspace:*` into concrete versions, which npm knows nothing about; `npm publish` does the OIDC
+# exchange for Trusted Publishing, which pnpm 11.8 cannot.
+#
+# Env: DRY_RUN=1 packs and validates without publishing.
+set -euo pipefail
+
+name=$(node -p 'require("./package.json").name')
+version=$(node -p 'require("./package.json").version')
+private=$(node -p 'require("./package.json").private === true')
+
+if [ "$private" = 'true' ]; then
+  echo "skip $name — private"
+  exit 0
+fi
+
+# Makes the step re-runnable after a release that failed halfway.
+if npm view "$name@$version" version >/dev/null 2>&1; then
+  echo "skip $name@$version — already on npm"
+  exit 0
+fi
+
+tarball=$(pnpm pack --pack-destination "${RUNNER_TEMP:-${TMPDIR:-/tmp}}" | tail -1)
+
+echo "publishing $name@$version from $tarball"
+# No --provenance flag: Trusted Publishing attaches a provenance attestation on its own.
+npm publish "$tarball" --access public ${DRY_RUN:+--dry-run}

--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,0 +1,76 @@
+// Builds the GitHub Release body: for each published package, the `## <version>` section of its
+// CHANGELOG.md. Packages the fixed group bumped without changes share one trailing list rather
+// than getting an empty heading each.
+//
+// Usage: pnpm ls -r --depth -1 --json | node release-notes.mjs 1.2.3
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error("usage: release-notes.mjs <version>");
+  process.exit(1);
+}
+
+/** Extract the body of the `## <version>` section from a changelog. */
+const sectionFor = (changelog, wanted) => {
+  const lines = changelog.split("\n");
+  const start = lines.findIndex((line) => line.trim() === `## ${wanted}`);
+
+  if (start === -1) return "";
+
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith("## "));
+
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
+};
+
+const readStdin = async () => {
+  const chunks = [];
+
+  for await (const chunk of process.stdin) chunks.push(chunk);
+
+  return Buffer.concat(chunks).toString("utf8");
+};
+
+const packages = JSON.parse(await readStdin())
+  .filter((pkg) => !pkg.private)
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const sections = [];
+const withoutNotes = [];
+
+for (const pkg of packages) {
+  let changelog = "";
+
+  try {
+    changelog = readFileSync(join(pkg.path, "CHANGELOG.md"), "utf8");
+  } catch {
+    // A package published for the first time may not have a changelog yet.
+  }
+
+  const notes = sectionFor(changelog, version);
+
+  if (notes) {
+    // Demote the changelog's own `###` headings so they nest under the package name.
+    sections.push(`## ${pkg.name}\n\n${notes.replace(/^### /gm, "#### ")}`);
+  } else {
+    withoutNotes.push(pkg.name);
+  }
+}
+
+const body = [...sections];
+
+if (withoutNotes.length > 0) {
+  body.push(
+    `## Released without changes\n\n${withoutNotes.map((name) => `- \`${name}\``).join("\n")}`,
+  );
+}
+
+if (body.length === 0) {
+  body.push(`No changelog entries found for \`${version}\`.`);
+}
+
+console.log(body.join("\n\n"));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+# npm auth is Trusted Publishing: no NPM_TOKEN, npm verifies this workflow's OIDC claim instead.
+# Hence `id-token: write`, and publishing through the npm CLI — pnpm 11.8 cannot do the exchange.
+#
+# A trusted publisher can only be attached to a package that already exists, so a package whose
+# first version has never been published must go out by hand once before this can release it.
+# `main` must also accept pushes from github-actions[bot].
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Version and verify, but do not push, publish or tag'
+        type: boolean
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+defaults:
+  run:
+    working-directory: dxlink-javascript
+
+env:
+  # Both pull @dxscript/* from the internal Nexus, which GitHub-hosted runners cannot reach.
+  # dxscript is still versioned by changesets; it just has to be published from inside the network.
+  PNPM_FILTER: >-
+    --filter=!@dxfeed/dxlink-console-dxscript
+    --filter=!@dxfeed/dxlink-debug-console
+
+jobs:
+  release:
+    name: Version and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: dxlink-javascript/pnpm-lock.yaml
+
+      - name: Ensure npm supports Trusted Publishing
+        run: |
+          npm install -g 'npm@^11.5.1'
+          npm --version
+
+      - name: Fail if there is nothing to release
+        run: |
+          if [ -z "$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' -print -quit)" ]; then
+            echo "::error::No pending changesets in .changeset — nothing to release."
+            exit 1
+          fi
+
+      - name: Install
+        run: pnpm install --frozen-lockfile $PNPM_FILTER
+
+      - name: Apply changesets
+        run: pnpm changeset version
+
+      - name: Read released version
+        id: version
+        # One `fixed` group in .changeset/config.json, so any package reports the release version.
+        run: echo "version=$(node -p "require('./dxlink-core/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Build, test and lint
+        run: pnpm turbo run build test lint $PNPM_FILTER
+
+      - name: Commit and push version bump
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m 'chore(release): v${{ steps.version.outputs.version }}'
+          git push origin HEAD:${{ github.ref_name }}
+
+      - name: Publish to npm
+        # `pnpm -r exec` walks the workspace in topological order.
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
+        run: pnpm -r $PNPM_FILTER exec bash "$GITHUB_WORKSPACE/.github/scripts/publish-package.sh"
+
+      - name: Tag the release
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag 'v${{ steps.version.outputs.version }}'
+          git push origin 'v${{ steps.version.outputs.version }}'
+
+      - name: Collect release notes
+        id: notes
+        run: |
+          pnpm ls -r --depth -1 --json $PNPM_FILTER \
+            | node "$GITHUB_WORKSPACE/.github/scripts/release-notes.mjs" '${{ steps.version.outputs.version }}' \
+            > "$RUNNER_TEMP/release-notes.md"
+          cat "$RUNNER_TEMP/release-notes.md"
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create 'v${{ steps.version.outputs.version }}' \
+            --title 'v${{ steps.version.outputs.version }}' \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            --repo '${{ github.repository }}'

--- a/dxlink-javascript/dxlink-api/package.json
+++ b/dxlink-javascript/dxlink-api/package.json
@@ -49,10 +49,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "files": [

--- a/dxlink-javascript/dxlink-console/core/package.json
+++ b/dxlink-javascript/dxlink-console/core/package.json
@@ -60,10 +60,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-console/dxscript/package.json
+++ b/dxlink-javascript/dxlink-console/dxscript/package.json
@@ -66,10 +66,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-console/market-data/package.json
+++ b/dxlink-javascript/dxlink-console/market-data/package.json
@@ -82,10 +82,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-console/rpc/package.json
+++ b/dxlink-javascript/dxlink-console/rpc/package.json
@@ -63,10 +63,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-core/package.json
+++ b/dxlink-javascript/dxlink-core/package.json
@@ -38,10 +38,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [],

--- a/dxlink-javascript/dxlink-dom/package.json
+++ b/dxlink-javascript/dxlink-dom/package.json
@@ -40,10 +40,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-feed/package.json
+++ b/dxlink-javascript/dxlink-feed/package.json
@@ -40,10 +40,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-indichart/package.json
+++ b/dxlink-javascript/dxlink-indichart/package.json
@@ -40,10 +40,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-protobuf-es/package.json
+++ b/dxlink-javascript/dxlink-protobuf-es/package.json
@@ -51,10 +51,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-rpc/package.json
+++ b/dxlink-javascript/dxlink-rpc/package.json
@@ -46,10 +46,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [

--- a/dxlink-javascript/dxlink-websocket-client/package.json
+++ b/dxlink-javascript/dxlink-websocket-client/package.json
@@ -43,10 +43,10 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/dxfeed/dxlink.git"
+    "url": "git+https://github.com/dxFeed/dxLink.git"
   },
   "bugs": {
-    "url": "https://github.com/dxfeed/dxlink/issues"
+    "url": "https://github.com/dxFeed/dxLink/issues"
   },
   "homepage": "https://dxfeed.com/",
   "keywords": [


### PR DESCRIPTION
Adds a manual release pipeline for the `dxlink-javascript` workspace, and fixes the one thing that would have rejected its first publish.

## The workflow

`workflow_dispatch` on `.github/workflows/release.yml`:

1. Fails fast if `.changeset/` holds nothing but `README.md`.
2. `pnpm install --frozen-lockfile` over the filtered workspace.
3. `pnpm changeset version` — consumes the changesets, bumps the `fixed` group, writes CHANGELOGs.
4. `pnpm turbo run build test lint`.
5. Commits `chore(release): vX.Y.Z` and pushes.
6. Publishes to npm.
7. Tags `vX.Y.Z` and cuts a GitHub Release, with notes assembled from each package's CHANGELOG section.

A `dry_run` input stops before push, publish and tag, and turns the publish into `--dry-run`.

## npm auth: Trusted Publishing, no stored token

No `NPM_TOKEN` anywhere — npm verifies the workflow's GitHub OIDC claim, hence `id-token: write`. Trusted publishers are already configured on all seven published packages (`repo=dxFeed/dxLink`, `file=release.yml`, `perms=publish, stage publish`).

Publishing splits across both package managers because neither half can do the other's job:

- `pnpm pack` rewrites `workspace:*` into concrete versions — npm doesn't know the workspace protocol.
- `npm publish` does the OIDC exchange — pnpm 11.8 can't.

`pnpm -r exec` drives `.github/scripts/publish-package.sh` in topological order. It skips private packages and versions already on the registry, so a half-failed release is re-runnable.

## Repository URL fix

All 12 published packages declared `git+ssh://git@github.com/dxfeed/dxlink.git` while the repo is `dxFeed/dxLink`. Trusted Publishing attaches provenance automatically and the registry validates it against that field, so the mismatch would have rejected the first publish. Normalized to the https form the workspace root already used.

## What is excluded, and why

`@dxfeed/dxlink-console-dxscript` and `@dxfeed/dxlink-debug-console` both pull `@dxscript/*` from the internal Nexus, unreachable from GitHub-hosted runners, so neither can be installed or built here. The app is private and would never publish anyway. dxscript is still versioned by changesets — it stays in the fixed group — but has to be published by hand from inside the network.

I confirmed the build is the only thing that needs those deps: with `@dxscript/*` removed, dxscript still builds correctly (both kept external, no `@dxscript` reference in the emitted `.d.ts`), but `typecheck` fails with 4 × TS2307 and one test file won't load. Publishing it from CI would mean a materially weaker gate.

## Verified locally

- `changeset version` bumps the workspace to `0.10.0` (console packages jump `0.8.1 → 0.10.0` — one `fixed` group).
- `turbo run build test lint` under the filter: 32 tasks green.
- `pnpm publish --dry-run` selects exactly the right 11 packages.
- The packed tarball rewrites `workspace:*` to `0.10.0`.
- `npm publish` accepts a pnpm-packed tarball.
- Release notes render correctly from the five pending changesets.

## Before merging / first run

- `main` must accept pushes from `github-actions[bot]`, or swap `GITHUB_TOKEN` for a PAT / App token in the checkout step.
- `workflow_dispatch` only shows up in the Actions tab once this is on the default branch, so the dry run has to wait for the merge.
- Four packages have never been published (`dxlink-protobuf-es`, `dxlink-console-core`, `dxlink-console-market-data`, `dxlink-console-rpc`). A trusted publisher can only be attached to an existing package, so each needs one manual publish before the workflow can release it.

Not addressed here: 5 open Dependabot alerts on `main` (`fast-uri` × 4 high, `esbuild` low). Unrelated to this change — separate PR.