### PR TITLE
fix(ci): make the release workflow actually run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
+        with:
+          # The workspace is not at the repo root, and `defaults.run.working-directory`
+          # does not apply to actions — so the packageManager field has to be pointed at.
+          package_json_file: dxlink-javascript/package.json
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Two failures from the first dry runs of the release workflow.

## 1. `Set up pnpm` — "No pnpm version is specified"

```
package_json_file: package.json
Error: No pnpm version is specified.
```

`pnpm/action-setup` reads `packageManager` from a `package.json` at the repo root, but this workspace lives in `dxlink-javascript/` and there is no root manifest. `defaults.run.working-directory` does not help — it applies to `run:` steps, not to actions. Pointed the action at `dxlink-javascript/package.json`.

This is already proven on a live runner: `ci.yml` in #45 uses the same setting and passes.

## 2. `Build, test and lint` — a full workspace install nobody asked for

```
Scope: all 14 workspace projects
[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/@dxscript/dxlink-dxscript-editor/-/...tgz
No authorization header was set for the request.
```

`@dxscript/dxlink-dxscript-editor` is excluded by `PNPM_FILTER`, so at first glance the filter looks broken. It is not. The giveaway is `Scope: all 14 workspace projects` — that is a *second, unfiltered* `pnpm install`, not the turbo run.

The chain:

1. `Install` does a filtered `pnpm install --frozen-lockfile`. Fine.
2. `Apply changesets` runs `changeset version`, which rewrites every `package.json`.
3. pnpm's deps-status check now finds `node_modules` stale relative to those manifests, and "repairs" it with a full, unfiltered install before running the command it was actually given (`runDepsStatusCheck` → `runPnpmCli` in the stack trace).
4. That install pulls the two `@dxscript/*` packages this job deliberately skipped.

It reached for registry.npmjs.org because `.npmrc` is gitignored, so the runner has no `@dxscript` registry mapping. That is a symptom, not the cause — the internal Nexus is unreachable from GitHub-hosted runners either way, so the correct behaviour is not to attempt the install at all.

Fixed by setting `pnpm_config_verify_deps_before_run: 'false'` at job level, which covers every pnpm call after the versioning step: turbo, `pnpm -r exec`, `pnpm pack` inside the publish script, and `pnpm ls` for the release notes.

`ci.yml` does not need this — it never mutates `package.json`, and its filtered install alone does not trip the check (proven by the green run on #45).
