### PR TITLE
ci: move actions onto their Node 24 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           # The workspace is not at the repo root, and `defaults.run.working-directory`
           # does not apply to actions — so the packageManager field has to be pointed at.
           package_json_file: dxlink-javascript/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,19 +44,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           # The workspace is not at the repo root, and `defaults.run.working-directory`
           # does not apply to actions — so the packageManager field has to be pointed at.
           package_json_file: dxlink-javascript/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
Every run of both workflows carries this annotation:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to
run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4
```

The runner is already forcing them onto Node 24, so nothing is actually running on Node 20 today — this pins versions that declare the runtime, and clears the annotation before the fallback goes away.

| Action | Before | After | `runs.using` |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | `node24` |
| `actions/setup-node` | v4 | **v7** | `node24` |
| `pnpm/action-setup` | v4 | **v6** | `node24` |

## Inputs verified at the new majors

I read each action's `action.yml` at the pinned tag rather than assuming, since these are three-, three- and two-major jumps:

- `checkout@v7` — `fetch-depth` present.
- `setup-node@v7` — `node-version`, `cache`, `cache-dependency-path` present.
- `pnpm/action-setup@v6` — `package_json_file` present, which matters: it is what points the action at `dxlink-javascript/package.json`, and losing it would reintroduce the "No pnpm version is specified" failure from #44.

## Behaviour changes worth knowing

- `checkout@v6` moved credential persistence to a separate file. The release workflow pushes the version commit using those credentials, so that path is exercised — worth watching on the next dry run, though `persist-credentials` still defaults to true.
- `checkout@v7` blocks checking out fork PRs for `pull_request_target` and `workflow_run`. Neither workflow uses those triggers.

CI runs on this PR, so `ci.yml` verifies itself. `release.yml` gets exercised by the next dry run.
